### PR TITLE
Fix: CCS in HelloRetryRequest tests

### DIFF
--- a/TLS-Testsuite/src/main/java/de/rub/nds/tlstest/suite/tests/server/tls13/rfc8446/HelloRetryRequest.java
+++ b/TLS-Testsuite/src/main/java/de/rub/nds/tlstest/suite/tests/server/tls13/rfc8446/HelloRetryRequest.java
@@ -7,6 +7,7 @@
  */
 package de.rub.nds.tlstest.suite.tests.server.tls13.rfc8446;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import de.rub.nds.modifiablevariable.util.Modifiable;
@@ -15,6 +16,7 @@ import de.rub.nds.tlsattacker.core.config.Config;
 import de.rub.nds.tlsattacker.core.constants.CipherSuite;
 import de.rub.nds.tlsattacker.core.constants.ExtensionType;
 import de.rub.nds.tlsattacker.core.constants.HandshakeMessageType;
+import de.rub.nds.tlsattacker.core.constants.ProtocolMessageType;
 import de.rub.nds.tlsattacker.core.protocol.message.ChangeCipherSpecMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.ClientHelloMessage;
 import de.rub.nds.tlsattacker.core.protocol.message.ServerHelloMessage;
@@ -165,6 +167,7 @@ public class HelloRetryRequest extends Tls13Test {
                 .validateFinal(
                         i -> {
                             Validator.executedAsPlanned(i);
+                            checkForDuplicateCcs(workflowTrace);
 
                             ServerHelloMessage helloRetryRequest =
                                     (ServerHelloMessage)
@@ -219,6 +222,7 @@ public class HelloRetryRequest extends Tls13Test {
                 .validateFinal(
                         i -> {
                             Validator.executedAsPlanned(i);
+                            checkForDuplicateCcs(workflowTrace);
 
                             ServerHelloMessage helloRetryRequest =
                                     (ServerHelloMessage)
@@ -270,6 +274,7 @@ public class HelloRetryRequest extends Tls13Test {
                 .validateFinal(
                         i -> {
                             Validator.executedAsPlanned(i);
+                            checkForDuplicateCcs(workflowTrace);
 
                             ServerHelloMessage helloRetryRequest =
                                     (ServerHelloMessage)
@@ -369,5 +374,17 @@ public class HelloRetryRequest extends Tls13Test {
 
         workflowTrace.addTlsActions(secondHelloTrace.getTlsActions());
         return workflowTrace;
+    }
+
+    private void checkForDuplicateCcs(WorkflowTrace executedTrace) {
+        // due to our workflow structure, CCS may be parsed with the first ServerHello or before the
+        // new
+        // ServerHello but it must not be sent twice by the server
+        assertFalse(
+                "Received more than one compatibility CCS from Server",
+                WorkflowTraceUtil.getAllReceivedMessages(
+                                        executedTrace, ProtocolMessageType.CHANGE_CIPHER_SPEC)
+                                .size()
+                        > 1);
     }
 }


### PR DESCRIPTION
Hi,
This PR addresses a problem rarely occurring in Botan's nightly CI, where we use TLS-Anvil server tests. I found no elegant way to reproduce the problem on my local machine. Luckily, the TLS-Anvil log gives a hint about what happens.

It seems, the problem is within the HelloRetryRequest tests, i.e., in its WorkflowTrace. Without this PR, the workflow for HelloRetryRequest tests looks like the following:

- **SendAction:** ClientHello
- **ReceiveAction:** ServerHello(HRR), _optional ChangeCipherSpec_
- **SendAction:** ClientHello
- **ReceiveAction:** ServerHello, _optional ChangeCipherSpec_, EncryptedExtensions, CertificateMessage, ...
- **SendAction:** ChangeCipherSpec

Most of the time, this workflow works fine. However, on rare occasions, the server's ChangeCipherSpec (CCS) is not received in the first ReceiveAction after HRR, but in the second one before the 'normal' ServerHello. I don't know how TLS-Attacker handles optional messages at the end of a ReceivingAction, but I imagine it does not wait long enough for the optional CSS to be received. Therefore, the log may look like the following (log snippet of a failed test):
```
10-04-2023_03:45:47 [pool-2-thread-1] INFO : ClientTcpTransportHandler.initialize(ClientTcpTransportHandler.java:115) - Connection established from ports 34652 -> 4433
10-04-2023_03:45:47 [pool-2-thread-1] INFO : SendAction.execute(SendAction.java:91) - Sending messages (client): CLIENT_HELLO,
10-04-2023_03:45:47 [pool-2-thread-1] INFO : TlsAction.execute(CommonReceiveAction.java:62) - Received Messages (client): SERVER_HELLO(HRR),
10-04-2023_03:45:47 [pool-2-thread-1] INFO : SendAction.execute(SendAction.java:91) - Sending messages (client): CLIENT_HELLO,
10-04-2023_03:45:47 [pool-2-thread-1] INFO : TlsAction.execute(CommonReceiveAction.java:62) - Received Messages (client): CHANGE_CIPHER_SPEC, SERVER_HELLO, ENCRYPTED_EXTENSIONS, CERTIFICATE, CERTIFICATE_VERIFY, FINISHED,
10-04-2023_03:45:47 [pool-2-thread-1] INFO : SendAction.execute(SendAction.java:91) - Sending messages (client): CHANGE_CIPHER_SPEC,
10-04-2023_03:45:52 [pool-2-thread-1] INFO : DefaultWorkflowExecutor.executeWorkflow(DefaultWorkflowExecutor.java:94) - Workflow was not executed as planned.
```

I think TLS-Attacker cannot know if a CCS is on the way to wait for it. Therefore, I think the only workaround is allowing an optional CCS just before the second ServerHello. With this PR, the workflow trace becomes the following:

 - **SendAction:** ClientHello
- **ReceiveAction:** ServerHello(HRR), _optional ChangeCipherSpec_
- **SendAction:** ClientHello
- **ReceiveAction:** _optional ChangeCipherSpec_, ServerHello, EncryptedExtensions, CertificateMessage, ...
- **SendAction:** ChangeCipherSpec

This removes the faulty optional CCS and adds one before the second ServerHello. Of course, in theory, this would allow two CCS messages, but I don't know how to prevent this. 

What do you think about this?
